### PR TITLE
fix typo darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ release: releases
 	make clean
 	rsync -av $(FILE_NAME) README.md LICENSE releases/$(FILE_NAME)
 	( cd releases; zip -r $(FILE_NAME)_noarch.zip $(FILE_NAME); )
-	for os in linux dawin; do \
+	for os in linux darwin; do \
 		for arch in 386 amd64; do \
 			ln releases/$(FILE_NAME)_noarch.zip releases/$(FILE_NAME)_$${os}_$${arch}.zip; \
 		done \


### PR DESCRIPTION
Unable to install by `mkr plugin install`.